### PR TITLE
Hotfix/keyboard updown

### DIFF
--- a/ExcelVerticalTab/ExcelVerticalTab.csproj
+++ b/ExcelVerticalTab/ExcelVerticalTab.csproj
@@ -216,6 +216,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <None Include="ExcelVerticalTab_TemporaryKey.pfx" />
+    <None Include="PPCustomZoom_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -255,10 +256,10 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>ExcelVerticalTab_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>PPCustomZoom_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>31D3E5DDDB6191712BE52EB59B7EB0F2575765FA</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>D43E5DE33C1036CCEBAE5059696B77E356CE4106</ManifestCertificateThumbprint>
   </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/VerticalTabControl/CustomListBox.cs
+++ b/VerticalTabControl/CustomListBox.cs
@@ -88,7 +88,7 @@ namespace VerticalTabControlLib
 
             var container = (UIElement)ItemContainerGenerator.ContainerFromItem(SelectedItem);
 
-            if (container != null)
+            if (container != null && IsFocused)
             {
                 container.Focus();
             }

--- a/VerticalTabControl/CustomListBox.cs
+++ b/VerticalTabControl/CustomListBox.cs
@@ -79,7 +79,21 @@ namespace VerticalTabControlLib
             if (originalSource == null) return null;
             return ContainerFromElement(originalSource) as FrameworkElement;
         }
-        
+
+        // Arrow keys don't work after programmatically setting ListView.SelectedItem
+        // https://stackoverflow.com/questions/7363777/arrow-keys-dont-work-after-programmatically-setting-listview-selecteditem
+        protected override void OnSelectionChanged(SelectionChangedEventArgs e)
+        {
+            base.OnSelectionChanged(e);
+
+            var container = (UIElement)ItemContainerGenerator.ContainerFromItem(SelectedItem);
+
+            if (container != null)
+            {
+                container.Focus();
+            }
+        }
+
         // 左クリック前
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
         {


### PR DESCRIPTION
WPF既知の問題っぽいListコントロールにおける矢印キー操作について修正を行いました。
クローンした結果、ClickOnseの証明書関連でエラーが出たため、別のブランチの修正を1つマージしました。
（それでもビルドできなかったため、最終的にソースだけのコミットとなります）

修正コードはStackOverFlowから引っ張ってきたものをそのまま引用しています。
よろしくお願いします。